### PR TITLE
REPO-4144: Enhance the bm driver to trigger renditions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.alfresco.tas</groupId>
             <artifactId>restapi-test</artifactId>
-            <version>5.2.0.12</version>
+            <version>5.2.0.13-SNAPSHOT</version>
         </dependency>
 
         <!-- TODO remove this dependency -->

--- a/src/main/java/org/alfresco/bm/dataload/files/SiteFolderLoader.java
+++ b/src/main/java/org/alfresco/bm/dataload/files/SiteFolderLoader.java
@@ -366,19 +366,23 @@ public class SiteFolderLoader extends AbstractRestApiEventProcessor
                 final String statusCodeRendition = restWrapper.getStatusCode();
                 logger.debug("Status code rendition: " + statusCodeRendition);
             }
-            // for some reason the system is not very happy to wait for doing these calls-
-            // there (may be) are timeouts on these events, and waiting a few seconds for the renditions responses may kill this event
-            if (false)
-            {
-                //Utility.retryCountSeconds = 30;
-                logger.debug("waiting for rendition to be created... ");
-                resumeTimer();
-                final RestRenditionInfoModel nodeRenditionUntilIsCreated = restWrapper.withCoreAPI().usingNode(file)
-                    .getNodeRenditionUntilIsCreated(renditionId);
-                suspendTimer();
-                logger.debug("Rendition creation status: " + nodeRenditionUntilIsCreated.getStatus());
-            }
+            // It is not advised to call waitForRenditionToBeCreated(restWrapper, file, renditionId);
+            // because renditions may take some time to be created.
         }
+    }
+
+    /**
+     * Careful with this method. Make sure you use it only if you understand the implications.
+     */
+    private void waitForRenditionToBeCreated(RestWrapper restWrapper, FileModel file, String renditionId) throws Exception
+    {
+        //if you want to change the default timeout modify this: Utility.retryCountSeconds = 30;
+        logger.debug("waiting for rendition to be created... ");
+        resumeTimer();
+        final RestRenditionInfoModel nodeRenditionUntilIsCreated = restWrapper.withCoreAPI().usingNode(file)
+            .getNodeRenditionUntilIsCreated(renditionId);
+        suspendTimer();
+        logger.debug("Rendition creation status: " + nodeRenditionUntilIsCreated.getStatus());
     }
 
     private boolean isRenditionTypeRequested(String renditionId)

--- a/src/main/java/org/alfresco/bm/dataload/files/SiteFolderLoader.java
+++ b/src/main/java/org/alfresco/bm/dataload/files/SiteFolderLoader.java
@@ -45,7 +45,10 @@ import org.alfresco.rest.core.RestWrapper;
 import org.alfresco.rest.model.RestErrorModel;
 import org.alfresco.rest.model.RestNodeBodyModel;
 import org.alfresco.rest.model.RestNodeModel;
+import org.alfresco.rest.model.RestRenditionInfoModel;
+import org.alfresco.rest.model.RestRenditionInfoModelCollection;
 import org.alfresco.utility.model.ContentModel;
+import org.alfresco.utility.model.FileModel;
 import org.alfresco.utility.model.UserModel;
 import org.apache.commons.logging.Log;
 import org.springframework.http.HttpStatus;
@@ -105,6 +108,9 @@ public class SiteFolderLoader extends AbstractRestApiEventProcessor
     private final TestFileService testFileService;
 
     private String eventNameSiteFolderLoaded;
+
+    private boolean requestRenditions;
+    private String renditionList;
 
     /**
      * Constructor
@@ -285,6 +291,7 @@ public class SiteFolderLoader extends AbstractRestApiEventProcessor
         }
     }
 
+
     private void createFile(String newFileName, File fileToUpload, ContentModel parentFolder, String parentFolderPath, UserModel userModel)
         throws Exception
     {
@@ -313,6 +320,10 @@ public class SiteFolderLoader extends AbstractRestApiEventProcessor
         {
             fileFolderService.incrementFileCount("", parentFolderPath, 1);
             logFileCreated(newFileNode);
+            if (isRequestRenditions())
+            {
+                triggerRenditions(userModel, restWrapper, newFileNode);
+            }
         }
         else if (isStatusConflict(statusCode))
         {
@@ -326,6 +337,71 @@ public class SiteFolderLoader extends AbstractRestApiEventProcessor
                     + ". Message: " + getRestCallErrorMessage(restWrapper);
             throw new RuntimeException(message);
         }
+    }
+
+    private void triggerRenditions(UserModel userModel, RestWrapper restWrapper, RestNodeModel newFileNode) throws Exception
+    {
+        final FileModel file = new FileModel();
+        file.setNodeRef(newFileNode.getId());
+
+        // Get supported renditions
+        logger.debug("Finding out all possible renditions for node: " + newFileNode.getId());
+        resumeTimer();
+        RestRenditionInfoModelCollection renditionsInfo = restWrapper.withCoreAPI().usingNode(file).getNodeRenditionsInfo();
+        suspendTimer();
+        for (RestRenditionInfoModel m : renditionsInfo.getEntries())
+        {
+            RestRenditionInfoModel renditionInfo = m.onModel();
+            String renditionId = renditionInfo.getId();
+            String targetMimeType = renditionInfo.getContent().getMimeType();
+            logger.debug("Supported rendition: " + renditionId + " target mime type: " + targetMimeType);
+
+            if (isRenditionTypeRequested(renditionId))
+            {
+                logger.debug("Requesting rendition: " + renditionId);
+                resumeTimer();
+                restWrapper.authenticateUser(userModel).withCoreAPI().usingNode(file).createNodeRendition(renditionId);
+                suspendTimer();
+
+                final String statusCodeRendition = restWrapper.getStatusCode();
+                logger.debug("Status code rendition: " + statusCodeRendition);
+            }
+            // for some reason the system is not very happy to wait for doing these calls-
+            // there (may be) are timeouts on these events, and waiting a few seconds for the renditions responses may kill this event
+            if (false)
+            {
+                //Utility.retryCountSeconds = 30;
+                logger.debug("waiting for rendition to be created... ");
+                resumeTimer();
+                final RestRenditionInfoModel nodeRenditionUntilIsCreated = restWrapper.withCoreAPI().usingNode(file)
+                    .getNodeRenditionUntilIsCreated(renditionId);
+                suspendTimer();
+                logger.debug("Rendition creation status: " + nodeRenditionUntilIsCreated.getStatus());
+            }
+        }
+    }
+
+    private boolean isRenditionTypeRequested(String renditionId)
+    {
+        if (renditionId==null || renditionId.isEmpty())
+        {
+            return false; // this is invalid
+        }
+        String renditionList = getRenditionList();
+        if (renditionList==null || renditionList.isEmpty())
+        {
+            //if the user had not specified any type of rendition, we will request rendition for all supported types
+            return true;
+        }
+        String[] types = renditionList.split(",");
+        for(String type: types)
+        {
+            if (renditionId.equals(type))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     // TODO the following few methods should go in the super class
@@ -387,6 +463,26 @@ public class SiteFolderLoader extends AbstractRestApiEventProcessor
     public void setEventNameSiteFolderLoaded(String eventNameSiteFolderLoaded)
     {
         this.eventNameSiteFolderLoaded = eventNameSiteFolderLoaded;
+    }
+
+    public boolean isRequestRenditions()
+    {
+        return requestRenditions;
+    }
+
+    public void setRequestRenditions(boolean requestRenditions)
+    {
+        this.requestRenditions = requestRenditions;
+    }
+
+    public String getRenditionList()
+    {
+        return renditionList;
+    }
+
+    public void setRenditionList(String renditionList)
+    {
+        this.renditionList = renditionList;
     }
 
     /**

--- a/src/main/resources/config/defaults/dataload.properties
+++ b/src/main/resources/config/defaults/dataload.properties
@@ -165,7 +165,7 @@ DATALOAD.siteLoad.requestRenditions.description=This will trigger the generation
 DATALOAD.siteLoad.requestRenditions.group=Files and Folders
 DATALOAD.siteLoad.renditionList.default=doclib,pdf,imgpreview,avatar
 DATALOAD.siteLoad.renditionList.type=string
-DATALOAD.siteLoad.renditionList.title=Rendition to be requested
+DATALOAD.siteLoad.renditionList.title=Renditions to be requested
 DATALOAD.siteLoad.renditionList.description=CSV list. A subset of the supported renditions will be requested. If empty, all supported renditions will be requested.
 DATALOAD.siteLoad.renditionList.group=Files and Folders
 

--- a/src/main/resources/config/defaults/dataload.properties
+++ b/src/main/resources/config/defaults/dataload.properties
@@ -158,3 +158,14 @@ DATALOAD.siteLoad.deleteFolderPercentage.type=int
 DATALOAD.siteLoad.deleteFolderPercentage.title=Delete Folder Percentage
 DATALOAD.siteLoad.deleteFolderPercentage.description=The percentage of folders to delete after file loading
 DATALOAD.siteLoad.deleteFolderPercentage.group=Files and Folders
+DATALOAD.siteLoad.requestRenditions.default=false
+DATALOAD.siteLoad.requestRenditions.type=boolean
+DATALOAD.siteLoad.requestRenditions.title=Request Renditions
+DATALOAD.siteLoad.requestRenditions.description=This will trigger the generation of renditions for any created file
+DATALOAD.siteLoad.requestRenditions.group=Files and Folders
+DATALOAD.siteLoad.renditionList.default=doclib,pdf,imgpreview,avatar
+DATALOAD.siteLoad.renditionList.type=string
+DATALOAD.siteLoad.renditionList.title=Rendition to be requested
+DATALOAD.siteLoad.renditionList.description=CSV list. A subset of the supported renditions will be requested. If empty, all supported renditions will be requested.
+DATALOAD.siteLoad.renditionList.group=Files and Folders
+

--- a/src/main/resources/config/spring/test-context.xml
+++ b/src/main/resources/config/spring/test-context.xml
@@ -148,6 +148,8 @@
         <property name="chart" value="true"/>
         <property name="eventNameSiteFolderLoaded" value="siteFoldersLoaded"/>
         <property name="baseUrl" value="${alfresco.url}"/>
+        <property name="requestRenditions" value="${siteLoad.requestRenditions}"/>
+        <property name="renditionList" value="${siteLoad.renditionList}"/>
     </bean>
     <bean id="producer.siteFoldersLoaded" class="org.alfresco.bm.driver.event.producer.TerminateEventProducer"
           parent="producer.base"/>
@@ -160,6 +162,8 @@
         <property name="chart" value="true"/>
         <property name="eventNameSiteFolderLoaded" value="cleanSiteFolder"/>
         <property name="baseUrl" value="${alfresco.url}"/>
+        <property name="requestRenditions" value="${siteLoad.requestRenditions}"/>
+        <property name="renditionList" value="${siteLoad.renditionList}"/>
     </bean>
 
     <bean id="event.cleanSiteFolder" class="org.alfresco.bm.dataload.files.CleanSiteFolder" parent="event.base">


### PR DESCRIPTION
Introduced a new feature: The ability to request the creations of some renditions for all the new files that get uploaded into ACS. 
This feature is controlled by a user settings available in the bm-driver Test and Test Run.
The list of renditions to actually be requested is the intersections of the user specified CSV list and the actual supported rendition set.
If the user specifies an empty CSV list for the renditions, then all the supported ones will be requested.